### PR TITLE
Add functional  templates

### DIFF
--- a/src/CribBlazor/Client/Components/CardList.razor
+++ b/src/CribBlazor/Client/Components/CardList.razor
@@ -1,5 +1,0 @@
-﻿<h3>CardList</h3>
-
-@code {
-
-}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/Failure.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/Failure.razor
@@ -1,0 +1,14 @@
+﻿@typeparam TSuccess
+@typeparam TFailure
+
+@Result.Match(
+	_ => null,
+	failure => @ChildContent(failure))
+
+@code {
+	[Parameter]
+	public Result<TSuccess, TFailure> Result { get; set; }
+
+	[Parameter]
+	public RenderFragment<TFailure> ChildContent { get; set; }
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/None.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/None.razor
@@ -1,0 +1,13 @@
+﻿@typeparam TValue
+
+@Option.Match(
+	some => null,
+	() => @ChildContent)
+
+@code {
+	[Parameter]
+	public Option<TValue> Option { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; }
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/OptionLoad.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/OptionLoad.razor
@@ -1,0 +1,33 @@
+﻿@typeparam TValue
+@using Microsoft.AspNetCore.Components;
+@using System.Threading.Tasks;
+@using Primitives = Functional;
+
+@_innerOption.Match(
+	some => some.Match(
+		 innerSome => Some(innerSome),
+		 () => None),
+	() => @<LoadingSpinnerContent />
+)
+
+@code {
+	[Parameter]
+	public Task<Primitives.Option<TValue>> Option { get; set; }
+
+	[Parameter]
+	public RenderFragment None { get; set; }
+
+	[Parameter]
+	public RenderFragment<TValue> Some { get; set; }
+
+	private Primitives.Option<Primitives.Option<TValue>> _innerOption { get; set; } = Primitives.Option.None<Primitives.Option<TValue>>();
+
+	protected override async Task OnParametersSetAsync()
+	{
+		var task = Option;
+		_innerOption = Primitives.Option.None<Primitives.Option<TValue>>();
+		var result = await Primitives.Option.SomeAsync(Option);
+		if (task == Option)
+			_innerOption = result;
+	}
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/OptionLoader.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/OptionLoader.razor
@@ -1,0 +1,44 @@
+﻿@typeparam TValue
+
+@_innerOption.Match(
+	some => some.Match(
+		 innerSome => Some(innerSome),
+		 () => None),
+	() => @<LoadingSpinnerContent />
+)
+
+@code {
+	[Parameter]
+	public Func<Task<Option<TValue>>> OptionFactory { get; set; }
+
+	[Parameter]
+	public RenderFragment<TValue> Some { get; set; }
+
+	[Parameter]
+	public RenderFragment None { get; set; }
+
+	private Task<Option<TValue>> _optionTask { get; set; } = null;
+	private Option<Option<TValue>> _innerOption { get; set; } = Option.None<Option<TValue>>();
+
+	protected override void OnInitialized()
+	{
+		_optionTask = OptionFactory();
+	}
+
+	protected override async Task OnParametersSetAsync()
+	{
+		if (_optionTask != null)
+		{
+			var task = _optionTask;
+			_innerOption = Option.None<Option<TValue>>();
+			var result = await Option.SomeAsync(task);
+			if (task == _optionTask)
+				_innerOption = result;
+		}
+	}
+
+	public void Refresh()
+	{
+		_optionTask = OptionFactory();
+	}
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/OptionMatch.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/OptionMatch.razor
@@ -1,0 +1,16 @@
+﻿@typeparam TValue
+
+@Option.Match(
+	some => Some(some),
+	() => None)
+
+@code {
+	[Parameter]
+	public Option<TValue> Option { get; set; }
+
+	[Parameter]
+	public RenderFragment<TValue> Some { get; set; }
+
+	[Parameter]
+	public RenderFragment None { get; set; }
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/ResultLoad.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/ResultLoad.razor
@@ -1,0 +1,31 @@
+﻿@typeparam TSuccess
+@typeparam TFailure
+
+@_innerResult.Match(
+	some => some.Match(
+		 success => Success(success),
+		 failure => Failure(failure)),
+	() => @<LoadingSpinnerContent />
+)
+
+@code {
+	[Parameter]
+	public Task<Result<TSuccess, TFailure>> Result { get; set; }
+
+	[Parameter]
+	public RenderFragment<TSuccess> Success { get; set; }
+
+	[Parameter]
+	public RenderFragment<TFailure> Failure { get; set; }
+
+	private Option<Result<TSuccess, TFailure>> _innerResult { get; set; } = Option.None<Result<TSuccess, TFailure>>();
+
+	protected override async Task OnParametersSetAsync()
+	{
+		var task = Result;
+		_innerResult = Option.None<Result<TSuccess, TFailure>>();
+		var result = await Option.SomeAsync(Result);
+		if (task == Result)
+			_innerResult = result;
+	}
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/ResultLoader.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/ResultLoader.razor
@@ -1,0 +1,83 @@
+﻿@typeparam TSuccess
+@typeparam TFailure
+
+<Animate @ref="@_loadingAnimator" style="@(_showContent ? "opacity:0;height:0;" : "opacity:1;height:0;")">
+	<LoadingSpinnerContent />
+</Animate>
+<Animate @ref="@_contentAnimator" style="@(_showContent ? "opacity:1" : "opacity:0")" Delay="@AnimationDuration.DefaultTransition">
+	@_innerResult.Match(
+		some => some.Match(
+		success => Success(success),
+		failure => Failure(failure)),
+		() => null)
+</Animate>
+
+@code {
+	[Parameter]
+	public Func<Task<Result<TSuccess, TFailure>>> ResultFactory { get; set; }
+
+	[Parameter]
+	public RenderFragment<TSuccess> Success { get; set; }
+
+	[Parameter]
+	public RenderFragment<TFailure> Failure { get; set; }
+
+	private Animate _contentAnimator;
+	private Animate _loadingAnimator;
+
+	private Task<Result<TSuccess, TFailure>> _resultTask { get; set; } = null;
+	private Option<Result<TSuccess, TFailure>> _innerResult { get; set; } = Option.None<Result<TSuccess, TFailure>>();
+	private bool _showContent = false;
+
+	protected override void OnInitialized()
+	{
+		_resultTask = ResultFactory();
+	}
+
+	protected override async Task OnParametersSetAsync()
+	{
+		await base.OnParametersSetAsync();
+		await ExecuteRefresh();
+	}
+
+	private async Task ExecuteRefresh()
+	{
+		if (_resultTask != null)
+		{
+			HideContent();
+			var task = _resultTask;
+			var result = await Option.SomeAsync(task);
+			if (task == _resultTask)
+			{
+				_innerResult = result;
+				ShowContent();
+			}
+		}
+	}
+
+	private void HideContent()
+	{
+		if (_contentAnimator != null && _loadingAnimator != null)
+		{
+			_contentAnimator.Delay = TimeSpan.Zero;
+			_loadingAnimator.Delay = AnimationDuration.DefaultTransition;
+		}
+		_showContent = false;
+	}
+
+	private void ShowContent()
+	{
+		if (_contentAnimator != null && _loadingAnimator != null)
+		{
+			_contentAnimator.Delay = AnimationDuration.DefaultTransition;
+			_loadingAnimator.Delay = TimeSpan.Zero;
+		}
+		_showContent = true;
+	}
+
+	public async Task Refresh()
+	{
+		_resultTask = ResultFactory();
+		await ExecuteRefresh();
+	}
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/ResultMatch.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/ResultMatch.razor
@@ -1,0 +1,18 @@
+﻿@typeparam TSuccess
+@typeparam TFailure
+
+@Result.Match(
+	success => Success(success),
+	failure => Failure(failure)
+)
+
+@code {
+	[Parameter]
+	public Result<TSuccess, TFailure> Result { get; set; }
+
+	[Parameter]
+	public RenderFragment<TSuccess> Success { get; set; }
+
+	[Parameter]
+	public RenderFragment<TFailure> Failure { get; set; }
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/Some.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/Some.razor
@@ -1,0 +1,13 @@
+﻿@typeparam TValue
+
+@Option.Match(
+	some => @ChildContent(some),
+	() => null)
+
+@code {
+	[Parameter]
+	public Option<TValue> Option { get; set; }
+
+	[Parameter]
+	public RenderFragment<TValue> ChildContent { get; set; }
+}

--- a/src/CribBlazor/Client/Components/FunctionalComponents/Success.razor
+++ b/src/CribBlazor/Client/Components/FunctionalComponents/Success.razor
@@ -1,0 +1,14 @@
+﻿@typeparam TSuccess
+@typeparam TFailure
+
+@Result.Match(
+	success => @ChildContent(success),
+	_ => null)
+
+@code {
+	[Parameter]
+	public Result<TSuccess, TFailure> Result { get; set; }
+
+	[Parameter]
+	public RenderFragment<TSuccess> ChildContent { get; set; }
+}

--- a/src/CribBlazor/Client/Components/LoadingSpinner.razor
+++ b/src/CribBlazor/Client/Components/LoadingSpinner.razor
@@ -1,0 +1,16 @@
+﻿@if (IsLoading)
+{
+	<LoadingSpinnerContent />
+}
+else
+{
+	@ChildContent
+}
+
+@code {
+	[Parameter]
+	public bool IsLoading { get; set; }
+
+	[Parameter]
+	public RenderFragment ChildContent { get; set; }
+}

--- a/src/CribBlazor/Client/Components/LoadingSpinnerContent.razor
+++ b/src/CribBlazor/Client/Components/LoadingSpinnerContent.razor
@@ -1,0 +1,6 @@
+﻿<div>Loading...</div>
+
+@code {
+	[Parameter]
+	public string Text { get; set; }
+}

--- a/src/CribBlazor/Client/Constants.cs
+++ b/src/CribBlazor/Client/Constants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CribBlazor.Client
+{
+	public static class AnimationDuration
+	{
+		public static TimeSpan DefaultTransition = TimeSpan.FromMilliseconds(250);
+		public static TimeSpan PageTransition = TimeSpan.FromMilliseconds(50);
+	}
+}

--- a/src/CribBlazor/Client/CribBlazor.Client.csproj
+++ b/src/CribBlazor/Client/CribBlazor.Client.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BlazorAnimate" Version="2.0.0" />
     <PackageReference Include="Functional.All" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />

--- a/src/CribBlazor/Client/Pages/Index.razor
+++ b/src/CribBlazor/Client/Pages/Index.razor
@@ -6,7 +6,7 @@
 @using CribBlazor.Shared.Errors;
 @using CribBlazor.Client.Components;
 @using System.Linq;
-@using Functional;
+@using CribBlazor.Client.Components.FunctionalComponents;
 @inject NavigationManager NavigationManager;
 @inject CreateFullDeck CreateFullDeck;
 @implements IDisposable
@@ -28,19 +28,19 @@
 
 <br />
 
-@if (Deck.HasValue())
-{
-	<ul id="deckList">
-		@foreach (var card in Deck.ValueOrDefault().Cards)
-		{
-			<li>@card.Face - @card.Suit</li>
-		}
-	</ul>
-}
-else
-{
-	<div>No deck yet...</div>
-}
+<OptionMatch Option="@Deck">
+	<None>
+		<div>No deck yet...</div>
+	</None>
+	<Some Context="deck">
+		<ul>
+			@foreach (var card in deck.Cards)
+			{
+				<li>@card.Face - @card.Suit</li>
+			}
+		</ul>
+	</Some>
+</OptionMatch>
 
 @code {
 	private HubConnection cardHubConnection;

--- a/src/CribBlazor/Client/_Imports.razor
+++ b/src/CribBlazor/Client/_Imports.razor
@@ -8,3 +8,5 @@
 @using CribBlazor.Client
 @using CribBlazor.Client.Shared
 @using CribBlazor.Game;
+@using BlazorAnimate;
+@using Functional;

--- a/src/CribBlazor/Client/wwwroot/index.html
+++ b/src/CribBlazor/Client/wwwroot/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 
 <head>
@@ -8,6 +8,7 @@
     <base href="/" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
+    <script src="_content/BlazorAnimate/blazorAnimateInterop.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
These components were suggested by my coworker, who has done a bunch of hackathon-based Functional Blazor. The syntax works like:

```
<ResultMatch Result="@_scoringHandler">
    <Failure>
        <Alert>Bad things happened</Alert>
    </Failure>
    <Success Context="scoringHandlerResult">
        <div>@scoringHandlerResult points</div>
    </Success>
</ResultMatch>
```

This also adds [`BlazorAnimate`](https://github.com/mikoskinen/Blazor.Animate) for pretty animations.